### PR TITLE
プライバシーポリシーページのリンクリストをFooter内に作成 #50

### DIFF
--- a/src/app/privacy/layout.tsx
+++ b/src/app/privacy/layout.tsx
@@ -1,0 +1,9 @@
+import SingleLayout from "@components/layouts/SingleLayout";
+
+export default function PrivacyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return SingleLayout({ children });
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,4 @@
-import '@/app/globals.css'
+import "@/app/globals.css";
 
 export default async function PrivacyPage() {
   return (

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,9 @@
+import '@/app/globals.css'
+
+export default async function PrivacyPage() {
+  return (
+    <>
+      <h2>プライバシーポリシー</h2>
+    </>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,8 @@
 export default function Footer() {
-  const footerItems = [{ text: "利用規約", url: "/tos" }];
+  const footerItems = [
+    { text: "利用規約", url: "/tos" },
+    { text: "プライバシーポリシー", url: "/privacy" },
+  ];
 
   return (
     <footer className="footer footer-center bg-base-300 text-base-content p-4">

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -43,6 +43,7 @@ export async function updateSession(request: NextRequest) {
     !request.nextUrl.pathname.startsWith("/signup") &&
     !request.nextUrl.pathname.startsWith("/auth") &&
     !request.nextUrl.pathname.startsWith("/tos") &&
+    !request.nextUrl.pathname.startsWith("/privacy") &&
     request.nextUrl.pathname !== "/"
   ) {
     // no user, potentially respond by redirecting the user to the login page


### PR DESCRIPTION
## Issue

- #50 

## 概要
プライバシーポリシーページを作成しました。

- `/privacy` ページを追加
  - layout.tsx と page.tsx を作成
- Supabaseミドルウェアを修正し、`/privacy` ページへのアクセスを許可
- Footer にプライバシーポリシーへのリンクを追加

## 変更確認方法

1. ブランチ`feature/create-privacy-policy-page`をローカルに取り込む
2. `npm run dev`でローカル環境を立ち上げる

## 変更前

<img width="1321" alt="スクリーンショット 2025-01-22 23 17 24" src="https://github.com/user-attachments/assets/d8c4e0c3-c2ee-4eb9-8b92-3f1e219bfe2b" />

## 変更後

<img width="1315" alt="スクリーンショット 2025-01-23 2 30 52" src="https://github.com/user-attachments/assets/c4363ca9-08e0-4598-bb84-d9631ca64c57" />

## マージ時にissueを自動でクローズ
Closes #50