### PR TITLE
ドキュメント削除

### DIFF
--- a/e2e/docs/[id]/page.e2e.test.ts
+++ b/e2e/docs/[id]/page.e2e.test.ts
@@ -6,17 +6,38 @@ import type { Database } from "@/lib/database.types";
 const test = withSupawright<Database, "public">(["public"]);
 
 describe("DocList E2E test", () => {
-  test.beforeEach(async ({ supawright }) => {
-    await supawright.create("public", "docs", {
-      title: "Test Document",
-      body: "This is a test document.",
-      user_id: "acfeb157-6c90-4d70-ad96-1d6361c1874e",
-      last_updated_user_id: "acfeb157-6c90-4d70-ad96-1d6361c1874e",
+  test.describe.serial("document detail", () => {
+    test.beforeEach(async ({ supawright }) => {
+      await supawright.create("public", "docs", {
+        title: "Test Document",
+        body: "This is a test document.",
+        user_id: "acfeb157-6c90-4d70-ad96-1d6361c1874e",
+        last_updated_user_id: "acfeb157-6c90-4d70-ad96-1d6361c1874e",
+      });
     });
-  });
 
-  describe("document detail", () => {
-    test("should display test docs in detail screen", async ({ page }) => {
+    describe("document detail", () => {
+      test("should display test docs in detail screen", async ({ page }) => {
+        await page.goto("http://localhost:3000/");
+
+        await page.getByRole("link", { name: "Docs" }).click();
+        await page.waitForLoadState("networkidle");
+        await expect(page.getByText("Test Document")).toBeVisible();
+        await page.getByText("Test Document").click();
+        await page.waitForLoadState("networkidle");
+        await expect(
+          page.locator('div:has-text("Test Document")').first(),
+        ).toBeVisible();
+        await expect(
+          page.locator('p:has-text("This is a test document.")'),
+        ).toBeVisible();
+        await expect(page.locator('p:has-text("User:")')).toBeVisible();
+        await expect(page.locator('p:has-text("Created At:")')).toBeVisible();
+        await expect(page.locator('p:has-text("Updated At:")')).toBeVisible();
+      });
+    });
+
+    test("delete doc in detail screen", async ({ page }) => {
       await page.goto("http://localhost:3000/");
 
       await page.getByRole("link", { name: "Docs" }).click();
@@ -24,33 +45,17 @@ describe("DocList E2E test", () => {
       await expect(page.getByText("Test Document")).toBeVisible();
       await page.getByText("Test Document").click();
       await page.waitForLoadState("networkidle");
-      await expect(
-        page.locator('div:has-text("Test Document")').first(),
-      ).toBeVisible();
+
+      page.once("dialog", async (dialog) => {
+        console.log(`Dialog message: ${dialog.message()}`);
+        await dialog.accept();
+      });
+
+      await page.getByRole("button", { name: "削除する" }).click();
+      await page.waitForLoadState("networkidle");
       await expect(
         page.locator('p:has-text("This is a test document.")'),
-      ).toBeVisible();
-      await expect(page.locator('p:has-text("User:")')).toBeVisible();
-      await expect(page.locator('p:has-text("Created At:")')).toBeVisible();
-      await expect(page.locator('p:has-text("Updated At:")')).toBeVisible();
+      ).toHaveCount(0);
     });
-  });
-
-  test("delete doc in detail screen", async ({ page }) => {
-    await page.goto("http://localhost:3000/");
-    await page.getByRole("link", { name: "Docs" }).click();
-    await page.getByRole("link", { name: "Test Document" }).first().click();
-    await page.waitForLoadState("networkidle");
-
-    page.once("dialog", async (dialog) => {
-      console.log(`Dialog message: ${dialog.message()}`);
-      await dialog.accept();
-    });
-
-    await page.getByRole("button", { name: "ドキュメントを削除する" }).click();
-    await page.waitForLoadState("networkidle");
-    await expect(
-      page.locator('p:has-text("This is a test document.")'),
-    ).toHaveCount(0);
   });
 });

--- a/e2e/docs/[id]/page.e2e.test.ts
+++ b/e2e/docs/[id]/page.e2e.test.ts
@@ -35,4 +35,22 @@ describe("DocList E2E test", () => {
       await expect(page.locator('p:has-text("Updated At:")')).toBeVisible();
     });
   });
+
+  test("delete doc in detail screen", async ({ page }) => {
+    await page.goto("http://localhost:3000/");
+    await page.getByRole("link", { name: "Docs" }).click();
+    await page.getByRole("link", { name: "Test Document" }).first().click();
+    await page.waitForLoadState("networkidle");
+
+    page.once("dialog", async (dialog) => {
+      console.log(`Dialog message: ${dialog.message()}`);
+      await dialog.accept();
+    });
+
+    await page.getByRole("button", { name: "ドキュメントを削除する" }).click();
+    await page.waitForLoadState("networkidle");
+    await expect(
+      page.locator('p:has-text("This is a test document.")'),
+    ).toHaveCount(0);
+  });
 });

--- a/src/app/docs/[id]/page.tsx
+++ b/src/app/docs/[id]/page.tsx
@@ -3,6 +3,7 @@ import supabase from "@/lib/supabase";
 import { createClient } from "@/lib/supabaseServer";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import SingleLayout from "@/components/layouts/SingleLayout";
+import DocDeleteButton from "@/components/DocDeleteButton";
 
 export default async function DocDetails({
   params,
@@ -17,7 +18,9 @@ export default async function DocDetails({
     .eq("id", Number(id))
     .single();
 
-  const { data: user, error: userError } = await (await createClient())
+  const { data: user, error: userError } = await (
+    await createClient()
+  )
     .from("users")
     .select("last_name")
     .eq("id", doc?.user_id ?? "")
@@ -38,6 +41,7 @@ export default async function DocDetails({
 
   return (
     <SingleLayout>
+      <DocDeleteButton id={id} />
       <Card className="p-6 max-w-2xl mx-auto my-6">
         <CardHeader>
           <div className="text-2xl font-bold">{doc.title}</div>

--- a/src/app/docs/[id]/page.tsx
+++ b/src/app/docs/[id]/page.tsx
@@ -41,12 +41,11 @@ export default async function DocDetails({
 
   return (
     <SingleLayout>
-      <DocDeleteButton id={id} />
-      <Card className="p-6 max-w-2xl mx-auto my-6">
+      <Card className="p-6 max-w-2xl mx-auto my-6 flex flex-col h-full">
         <CardHeader>
           <div className="text-2xl font-bold">{doc.title}</div>
         </CardHeader>
-        <CardContent>
+        <CardContent className="flex-grow">
           <p className="mb-4 text-lg">{doc.body}</p>
           <div className="space-y-2">
             <p>
@@ -63,6 +62,9 @@ export default async function DocDetails({
             </p>
           </div>
         </CardContent>
+        <div className="flex justify-end mt-4">
+          <DocDeleteButton id={id} />
+        </div>
       </Card>
     </SingleLayout>
   );

--- a/src/app/docs/[id]/page.tsx
+++ b/src/app/docs/[id]/page.tsx
@@ -3,7 +3,7 @@ import supabase from "@/lib/supabase";
 import { createClient } from "@/lib/supabaseServer";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import SingleLayout from "@/components/layouts/SingleLayout";
-import DocDeleteButton from "@/components/DocDeleteButton";
+import DocDeleteButton from "@/app/docs/_components/DocDeleteButton";
 
 export default async function DocDetails({
   params,

--- a/src/app/docs/_components/DocDeleteButton.tsx
+++ b/src/app/docs/_components/DocDeleteButton.tsx
@@ -17,7 +17,7 @@ export default function DocDeleteButton({ id }: { id: string }) {
       return;
     }
 
-    router.push("/docs");
+    router.replace("/docs");
   };
 
   return (

--- a/src/components/DocDeleteButton.tsx
+++ b/src/components/DocDeleteButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import supabase from "@/lib/supabase";
+
+export default function DocDeleteButton({ id }: { id: string }) {
+  const router = useRouter();
+
+  const onDelete = async () => {
+    if (!confirm("Are you sure you want to delete this document?")) return;
+
+    const { error } = await supabase.from("docs").delete().eq("id", Number(id));
+
+    if (error) {
+      console.error("Error deleting document:", error);
+      return;
+    }
+
+    router.push("/docs");
+  };
+
+  return (
+    <button
+      onClick={onDelete}
+      className="bg-red-500 text-white px-4 py-2 rounded"
+    >
+      ドキュメントを削除する
+    </button>
+  );
+}

--- a/src/components/DocDeleteButton.tsx
+++ b/src/components/DocDeleteButton.tsx
@@ -1,18 +1,19 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
 import supabase from "@/lib/supabase";
 
 export default function DocDeleteButton({ id }: { id: string }) {
   const router = useRouter();
 
   const onDelete = async () => {
-    if (!confirm("Are you sure you want to delete this document?")) return;
+    if (!confirm("本当によろしいですか？")) return;
 
     const { error } = await supabase.from("docs").delete().eq("id", Number(id));
 
     if (error) {
-      console.error("Error deleting document:", error);
+      console.error(`Error deleting document: ${error.code} ${error.message}`);
       return;
     }
 
@@ -20,11 +21,12 @@ export default function DocDeleteButton({ id }: { id: string }) {
   };
 
   return (
-    <button
+    <Button
       onClick={onDelete}
-      className="bg-red-500 text-white px-4 py-2 rounded"
+      variant="ghost"
+      className="text-gray-500 underline hover:text-red-500"
     >
-      ドキュメントを削除する
-    </button>
+      削除する
+    </Button>
   );
 }


### PR DESCRIPTION
## Issue
#17 

## 概要
- ドキュメント詳細ページにドキュメントを削除するボタンを設置
- `DocDeleteButton.tsx` の作成
　- ドキュメントを削除する前にダイアログを表示して確認する 
　- ドキュメント削除後、`docs` に移動する
- E2E テストの作成

<details>
![delete_doc](https://github.com/user-attachments/assets/68f57b47-9a84-43a7-bd60-ce3259b1d322)
</details>

![doc_delete](https://github.com/user-attachments/assets/0ca62548-faa3-4c04-9ea7-eb522ed45926)
