### PR TITLE
ドキュメント追加

### DIFF
--- a/e2e/docs/new/page.e2e.test.ts
+++ b/e2e/docs/new/page.e2e.test.ts
@@ -1,0 +1,53 @@
+import { describe } from "node:test";
+import { expect } from "@playwright/test";
+import { withSupawright } from "supawright";
+import type { Database } from "@/lib/database.types";
+import { E2E_CONFIG } from "../../constants";
+
+const test = withSupawright<Database, "public">(["public"]);
+
+describe("test to create new document", () => {
+  let validEmail: string | undefined;
+  const e2ePassword = "e2e_password";
+  test.beforeEach(async ({ supawright }) => {
+    const attributes = {
+      password: e2ePassword,
+      email_confirm: true,
+    };
+    const user = await supawright.createUser(attributes);
+    validEmail = user.email;
+  });
+
+  describe("crate a new document", () => {
+    test("should display test docs in detail screen", async ({ page }) => {
+      await page.goto(E2E_CONFIG.BASE_URL);
+      await page.getByRole("link", { name: "ログイン" }).click();
+      await page.getByPlaceholder("name@example.com").fill(validEmail ?? "");
+      await page.getByLabel("Password").fill(e2ePassword);
+      await page.getByRole("button", { name: "ログイン" }).click();
+
+      await page.getByRole("link", { name: "Docs" }).click();
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByText("Doc作成")).toBeVisible();
+      await page.getByText("Doc作成").click();
+      await page.waitForLoadState("networkidle");
+
+      await page
+        .getByPlaceholder("Enter title")
+        .fill(`this is test title with ${validEmail}`);
+      await page.getByPlaceholder("Enter body").fill("this is test body");
+      await page.getByRole("button", { name: "Docを公開" }).click();
+
+      await page
+        .getByText(`this is test title with ${validEmail}`, { exact: true })
+        .click();
+
+      page.once("dialog", async (dialog) => {
+        console.log(`Dialog message: ${dialog.message()}`);
+        await dialog.accept();
+      });
+
+      await page.getByRole("button", { name: "削除する" }).click();
+    });
+  });
+});

--- a/e2e/docs/new/page.e2e.test.ts
+++ b/e2e/docs/new/page.e2e.test.ts
@@ -8,10 +8,10 @@ const test = withSupawright<Database, "public">(["public"]);
 
 describe("test to create new document", () => {
   let validEmail: string | undefined;
-  const e2ePassword = "e2e_password";
+  const password = "e2e_password";
   test.beforeEach(async ({ supawright }) => {
     const attributes = {
-      password: e2ePassword,
+      password: password,
       email_confirm: true,
     };
     const user = await supawright.createUser(attributes);
@@ -23,7 +23,7 @@ describe("test to create new document", () => {
       await page.goto(E2E_CONFIG.BASE_URL);
       await page.getByRole("link", { name: "ログイン" }).click();
       await page.getByPlaceholder("name@example.com").fill(validEmail ?? "");
-      await page.getByLabel("Password").fill(e2ePassword);
+      await page.getByLabel("Password").fill(password);
       await page.getByRole("button", { name: "ログイン" }).click();
 
       await page.getByRole("link", { name: "Docs" }).click();
@@ -48,6 +48,10 @@ describe("test to create new document", () => {
       });
 
       await page.getByRole("button", { name: "削除する" }).click();
+
+      await expect(
+        page.getByText(`this is test title with ${validEmail}`),
+      ).not.toBeVisible();
     });
   });
 });

--- a/src/app/docs/_actions/createDoc.ts
+++ b/src/app/docs/_actions/createDoc.ts
@@ -4,8 +4,12 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabaseServer";
 
 export async function createDoc(formData: FormData) {
-  const title = formData.get("title") as string;
-  const body = formData.get("body") as string;
+  const titleRaw = formData.get("title");
+  const bodyRaw = formData.get("body");
+
+  if (typeof titleRaw !== "string" || typeof bodyRaw !== "string") {
+    throw new Error("Invalid form data");
+  }
 
   const supabase = await createClient();
   const {
@@ -21,8 +25,8 @@ export async function createDoc(formData: FormData) {
     .from("docs")
     .insert([
       {
-        title,
-        body,
+        titleRaw,
+        bodyRaw,
         user_id: user.id,
         last_updated_user_id: user.id,
       },

--- a/src/app/docs/_actions/createDoc.ts
+++ b/src/app/docs/_actions/createDoc.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabaseServer";
+import { createClient } from "@/utils/supabase/server";
 
 export async function createDoc(formData: FormData) {
   const title = formData.get("title");

--- a/src/app/docs/_actions/createDoc.ts
+++ b/src/app/docs/_actions/createDoc.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabaseServer";
+
+export async function createDoc(formData: FormData) {
+  const title = formData.get("title") as string;
+  const body = formData.get("body") as string;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    console.error(`ログインが必要です`);
+    return;
+  }
+
+  const { error } = await supabase
+    .from("docs")
+    .insert([
+      {
+        title,
+        body,
+        user_id: user.id,
+        last_updated_user_id: user.id,
+      },
+    ])
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error(
+      `ドキュメントの新規作成に失敗しました。 ${error.code} ${error.message}`,
+    );
+    return;
+  }
+
+  redirect("/docs");
+}

--- a/src/app/docs/_actions/createDoc.ts
+++ b/src/app/docs/_actions/createDoc.ts
@@ -4,11 +4,11 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabaseServer";
 
 export async function createDoc(formData: FormData) {
-  const titleRaw = formData.get("title");
-  const bodyRaw = formData.get("body");
+  const title = formData.get("title");
+  const body = formData.get("body");
 
-  if (typeof titleRaw !== "string" || typeof bodyRaw !== "string") {
-    throw new Error("Invalid form data");
+  if (typeof title !== "string" || typeof body !== "string") {
+    return { error: "Invalid form data" };
   }
 
   const supabase = await createClient();
@@ -17,16 +17,15 @@ export async function createDoc(formData: FormData) {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    console.error(`ログインが必要です`);
-    return;
+    return { error: "ログインが必要です" };
   }
 
   const { error } = await supabase
     .from("docs")
     .insert([
       {
-        titleRaw,
-        bodyRaw,
+        title,
+        body,
         user_id: user.id,
         last_updated_user_id: user.id,
       },
@@ -35,10 +34,9 @@ export async function createDoc(formData: FormData) {
     .single();
 
   if (error) {
-    console.error(
-      `ドキュメントの新規作成に失敗しました。 ${error.code} ${error.message}`,
-    );
-    return;
+    return {
+      error: `ドキュメントの新規作成に失敗しました。 ${error.code} ${error.message}`,
+    };
   }
 
   redirect("/docs");

--- a/src/app/docs/_components/Docs.tsx
+++ b/src/app/docs/_components/Docs.tsx
@@ -1,9 +1,18 @@
+import Link from "next/link";
 import DocList from "./DocList";
+import { Button } from "@/components/ui/button";
 
 export default function Docs() {
   return (
-    <div className="p-20px">
-      <h1>Docs</h1>
+    <div className="p-5">
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Docs</h1>
+        <Link href="/docs/new">
+          <Button className="mr-12 border border-black bg-white text-gray-800 px-6 py-1 rounded-md">
+            Doc作成
+          </Button>
+        </Link>
+      </div>
       <DocList itemsPerPage={20} />
     </div>
   );

--- a/src/app/docs/_components/newDocForm.tsx
+++ b/src/app/docs/_components/newDocForm.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/hooks/use-toast";
+import { createDoc } from "../_actions/createDoc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+export function NewDocForm() {
+  const { toast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const result = await createDoc(formData);
+
+    if (result?.error) {
+      toast({
+        title: "エラー",
+        description: result.error,
+        variant: "destructive",
+      });
+      setIsSubmitting(false);
+      return;
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <p className="mb-2">タイトル</p>
+      <Input
+        type="text"
+        name="title"
+        placeholder="Enter title"
+        className="mb-4"
+        required
+      />
+
+      <p className="mb-2">本文</p>
+      <Textarea
+        rows={10}
+        name="body"
+        placeholder="Enter body"
+        className="mb-4"
+        required
+      />
+
+      <div className="mb-4 flex justify-center items-center">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "送信中..." : "Docを公開"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/docs/new/page.tsx
+++ b/src/app/docs/new/page.tsx
@@ -1,0 +1,46 @@
+
+import { createDoc } from "../_actions/createDoc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import SingleLayout from "@/components/layouts/SingleLayout";
+
+export default function EditDoc() {
+  return (
+    <SingleLayout>
+      <div className="flex justify-center items-center min-h-screen p-6 relative">
+        <Card className="w-full max-w-xl">
+          <CardHeader>
+            <CardTitle>ドキュメント作成</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form action={createDoc}>
+              <p className="mb-2">タイトル</p>
+              <Input
+                type="text"
+                name="title"
+                placeholder="Enter title"
+                className="mb-4"
+                required
+              />
+
+              <p className="mb-2">本文</p>
+              <Textarea
+                rows={10}
+                name="body"
+                placeholder="Enter body"
+                className="mb-4"
+                required
+              />
+
+              <div className="mb-4 flex justify-center items-center">
+                <Button type="submit">Docを公開</Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </SingleLayout>
+  );
+}

--- a/src/app/docs/new/page.tsx
+++ b/src/app/docs/new/page.tsx
@@ -1,12 +1,8 @@
-
-import { createDoc } from "../_actions/createDoc";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import SingleLayout from "@/components/layouts/SingleLayout";
+import { NewDocForm } from "../_components/newDocForm";
 
-export default function EditDoc() {
+export default function NewDoc() {
   return (
     <SingleLayout>
       <div className="flex justify-center items-center min-h-screen p-6 relative">
@@ -15,29 +11,7 @@ export default function EditDoc() {
             <CardTitle>ドキュメント作成</CardTitle>
           </CardHeader>
           <CardContent>
-            <form action={createDoc}>
-              <p className="mb-2">タイトル</p>
-              <Input
-                type="text"
-                name="title"
-                placeholder="Enter title"
-                className="mb-4"
-                required
-              />
-
-              <p className="mb-2">本文</p>
-              <Textarea
-                rows={10}
-                name="body"
-                placeholder="Enter body"
-                className="mb-4"
-                required
-              />
-
-              <div className="mb-4 flex justify-center items-center">
-                <Button type="submit">Docを公開</Button>
-              </div>
-            </form>
+            <NewDocForm />
           </CardContent>
         </Card>
       </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts"
-  ],
+, "src/app/docs/_form/newDocForm.tss"  ],
   "exclude": [
     "node_modules"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,25 +18,12 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@styles/*": [
-        "./src/styles/*"
-      ],
-      "@components/*": [
-        "./src/components/*"
-      ]
+      "@/*": ["./src/*"],
+      "@styles/*": ["./src/styles/*"],
+      "@components/*": ["./src/components/*"]
     },
     "target": "ES2017"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-, "src/app/docs/_form/newDocForm.tss"  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Issue
#15 

## 概要
ドキュメントの新規作成ページを作成。
**ドキュメント新規作成時に `ユーザー id` が必要なためログインされていないとドキュメント新規作成はできない**
- `docs/new/page.tsx`
- `Docs` コンポネント内に `Doc作成` ボタンを配置
- E2E テストの作成
     - テストユーザーを作成、ログイン
     - Doc作成ボタンをクリックして新規作成ページに遷移
     - Title に `this is test title with ${validEmail}` を記入
     - Body に `this is test body` を記入
     - `Docを公開` ボタンをクリック
     - `this is test title with ${validEmail}` をドキュメント一覧からクリック
     - 削除ボタンをクリックしてテスト中に作成されたドキュメントを削除


![add_new_doc_e2e](https://github.com/user-attachments/assets/676ddfbc-6023-4396-8b64-5c91dec56c5a)
