### PR TITLE
e2eテストのreporterをdotした

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "run-s format:*",
     "lint": "next lint",
     "test:component": "jest",
-    "test:p2p": "playwright test",
+    "test:e2e": "playwright test",
     "test": "run-s test:*"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: "dot",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -30,7 +30,9 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+      },
     },
 
     // {


### PR DESCRIPTION
HTML reporterだと一々ブラウザが立ち上がり、
Terminalも処理が止まって不便なので。