### PR TITLE
トップページに運営企業のリンクを追加

### DIFF
--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import Footer from "./Footer";
+import "@testing-library/jest-dom";
+
+describe("Footer component", () => {
+  it("should display the correct link for the operating company", () => {
+    render(<Footer />);
+    const link = screen.getByRole("link", { name: "運営企業" });
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "https://lokka.jp");
+  });
+});

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,6 +16,10 @@ export default function Footer() {
               key={index}
               href={item.url}
               className="text-sm text-muted-foreground hover:text-foreground"
+              target={item.url.startsWith("http") ? "_blank" : undefined}
+              rel={
+                item.url.startsWith("http") ? "noopener noreferrer" : undefined
+              }
             >
               {item.text}
             </Link>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,7 @@ export default function Footer() {
   const footerItems = [
     { text: "利用規約", url: "/tos" },
     { text: "プライバシーポリシー", url: "/privacy" },
+    { text: "運営企業", url: "https://lokka.jp" },
   ];
 
   return (


### PR DESCRIPTION
#134 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - フッターに「運営企業」への外部リンクが追加されました。外部リンクは新しいタブで安全に開くようになりました。

- **テスト**
  - フッターに「運営企業」リンクが正しく表示されることを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->