### PR TITLE
docs: Supabase CLI 2.86以降のキー名表記に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,23 @@ cp .env.local.example .env.local
 ```
 
 `npx supabase status`で見れる各種設定値を`.env.local`に書く。
-*API URL*は`NEXT_PUBLIC_SUPABASE_URL`に、*anon key*を`NEXT_PUBLIC_SUPABASE_ANON_KEY`に設定する。
+*Project URL* (旧 API URL) を`NEXT_PUBLIC_SUPABASE_URL`に、*Publishable key* (旧 anon key) を`NEXT_PUBLIC_SUPABASE_ANON_KEY`に設定する。
 
 `.env.local`:
 
 ```
-NEXT_PUBLIC_SUPABASE_URL=API URLを設定する
-NEXT_PUBLIC_SUPABASE_ANON_KEY=anon keyを設定する
+NEXT_PUBLIC_SUPABASE_URL=Project URLを設定する
+NEXT_PUBLIC_SUPABASE_ANON_KEY=Publishable keyを設定する
 ```
+
+> Supabase CLI 2.86以降で`supabase status`の出力ラベルが変更されたが、JWT としては従来のanon keyと互換のため`NEXT_PUBLIC_SUPABASE_ANON_KEY`という変数名はそのまま使える。
+> 表形式の出力をシェルで扱いにくい場合は、以下のコマンドで直接`.env`形式の出力が得られる:
+>
+> ```console
+> npx supabase status -o env \
+>   --override-name api.url=NEXT_PUBLIC_SUPABASE_URL \
+>   --override-name auth.anon_key=NEXT_PUBLIC_SUPABASE_ANON_KEY
+> ```
 
 ## 実行
 


### PR DESCRIPTION
## Summary

#172 のフォローアップ。Supabase CLI 2.86 以降で \`supabase status\` の出力ラベルが変更されたため README を更新。

- API URL → Project URL
- anon key → Publishable key

JWT としては互換のため環境変数名 \`NEXT_PUBLIC_SUPABASE_ANON_KEY\` はそのまま使える。新しい表形式は手作業で値を抽出しにくいため、\`-o env\` での取得方法も追記した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)