### PR TITLE
chore: turbopack.rootを設定して複数lockfile警告を抑止

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,12 @@
+const path = require("path");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   allowedDevOrigins: ["127.0.0.1"],
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary

#175 のフォローアップ。Next.js 16 の workspace root 推論が、worktree を使った開発時に別ディレクトリの \`package-lock.json\` を検出して警告を出すため、\`turbopack.root\` を明示してルートを固定する。

## Test plan

- [x] \`npm run build\` で警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)