### PR TITLE
src/lib/supabase.ts を遅延初期化して Preview ビルドの prerender エラーを修正

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,9 +1,22 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { Database } from "@/lib/database.types";
 
-const supabase = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
-);
+let client: SupabaseClient<Database> | undefined;
+
+function getClient(): SupabaseClient<Database> {
+  if (!client) {
+    client = createClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+    );
+  }
+  return client;
+}
+
+const supabase = new Proxy({} as SupabaseClient<Database>, {
+  get(_target, prop, receiver) {
+    return Reflect.get(getClient(), prop, receiver);
+  },
+});
 
 export default supabase;


### PR DESCRIPTION
## Summary
- supabase-js 2.105+ で \`createClient\` が URL を即時検証するようになり、\`NEXT_PUBLIC_SUPABASE_URL\` が無い Vercel Preview ビルドの \`/companies\` プリレンダリングで \`Error: supabaseUrl is required\` で失敗していた
- \`src/lib/supabase.ts\` を Proxy 経由の遅延初期化に変更し、モジュール評価時に \`createClient\` を呼ばないようにした

## 影響範囲
- default import の形 (\`import supabase from "@/lib/supabase"\`) は変えていないので呼び出し側 (\`Companies.tsx\`, \`useDocs.ts\`, \`DocDeleteButton.tsx\`) は無修正
- ランタイムでの env var 要件は従来と同じ

## Test plan
- [ ] Vercel Preview デプロイが成功する
- [ ] Companies / docs ページが従来通り動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **最適化**
  * Supabaseクライアントの初期化を遅延ロード方式に変更しました。これによりアプリケーションの起動時間が改善され、リソース効率が向上しています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/agent/pull/191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->