### PR TITLE
Companies ページを Fjord direction デザインで再実装

### DIFF
--- a/src/app/companies/layout.tsx
+++ b/src/app/companies/layout.tsx
@@ -1,9 +1,28 @@
+import { Zen_Maru_Gothic, M_PLUS_Rounded_1c } from "next/font/google";
 import MultiLayout from "@components/layouts/MulitLayout";
 
-export default function DashboardLayout({
+const zenMaru = Zen_Maru_Gothic({
+  subsets: ["latin"],
+  weight: ["400", "500", "700", "900"],
+  display: "swap",
+  variable: "--font-zen-maru",
+});
+
+const mPlus = M_PLUS_Rounded_1c({
+  subsets: ["latin"],
+  weight: ["400", "500", "700", "800"],
+  display: "swap",
+  variable: "--font-mplus-rounded",
+});
+
+export default function CompaniesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return MultiLayout({ children });
+  return (
+    <div className={`${zenMaru.variable} ${mPlus.variable}`}>
+      <MultiLayout>{children}</MultiLayout>
+    </div>
+  );
 }

--- a/src/components/Companies.module.css
+++ b/src/components/Companies.module.css
@@ -1,0 +1,347 @@
+/* ===================================================================
+ * Companies — Fjord direction
+ * Scoped via CSS Modules. Tokens / classes are local-only;
+ * they do not affect any other page.
+ * =================================================================== */
+
+.wrapper {
+  --ink:        #0B2426;
+  --ink-2:      #2B4448;
+  --ink-3:      #5E7679;
+  --ink-4:      #8FA2A4;
+
+  --glacier:    #F4F8F8;
+  --glacier-2:  #EAF1F1;
+  --paper:      #FFFFFF;
+
+  --fjord:      #0E4A50;
+  --fjord-2:    #0A363B;
+  --mist:       #6FA8AC;
+  --moss:       #2D6E5A;
+  --amber:      #B5772E;
+  --berry:      #9B3247;
+
+  --line:       #D7E1E2;
+  --line-soft:  #E5ECEC;
+  --focus:      #6FA8AC;
+
+  --r-sm: 4px;
+  --r:    6px;
+  --r-lg: 8px;
+
+  --shadow-2: 0 1px 2px rgba(11,36,38,0.05), 0 12px 32px -16px rgba(11,36,38,0.16);
+
+  font-family: var(--font-zen-maru), var(--font-mplus-rounded), -apple-system,
+               "Hiragino Sans", "Yu Gothic UI", Meiryo, system-ui, sans-serif;
+  font-weight: 500;
+  color: var(--ink);
+  background: var(--glacier);
+  line-height: 1.6;
+  min-height: 100%;
+  -webkit-font-smoothing: antialiased;
+}
+
+.inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 48px 56px 96px;
+}
+
+/* ---- Page header ------------------------------------------------- */
+.pageHead {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 40px;
+}
+.tag {
+  font-family: var(--font-mplus-rounded), monospace;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--fjord);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.pageHead h1 {
+  margin: 0;
+  font-size: 38px;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.sub {
+  margin: 8px 0 0;
+  font-size: 14.5px;
+  color: var(--ink-3);
+  line-height: 1.8;
+  max-width: 48ch;
+}
+.actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* ---- Buttons ----------------------------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 18px;
+  border-radius: var(--r);
+  border: 1px solid transparent;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 13.5px;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.btnPrimary {
+  background: var(--fjord);
+  color: #fff;
+  box-shadow: 0 6px 14px -8px rgba(14, 74, 80, 0.6);
+}
+.btnPrimary:hover {
+  background: var(--fjord-2);
+}
+.btnGhost {
+  background: var(--paper);
+  border-color: var(--line);
+  color: var(--ink-2);
+}
+.btnGhost:hover {
+  border-color: var(--ink-4);
+  color: var(--ink);
+}
+
+/* ---- Toolbar (search + filter chips) ----------------------------- */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+.search {
+  max-width: 360px;
+  flex: 1;
+  position: relative;
+}
+.search input {
+  width: 100%;
+  height: 38px;
+  padding: 0 12px 0 38px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  font-family: inherit;
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--ink);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+.search input::placeholder {
+  color: var(--ink-4);
+}
+.search input:focus {
+  outline: none;
+  border-color: var(--mist);
+  box-shadow: 0 0 0 4px rgba(111, 168, 172, 0.18);
+}
+.searchIcon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ink-4);
+}
+.filterChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  border-radius: 999px;
+  font-size: 12.5px;
+  color: var(--ink-2);
+  cursor: pointer;
+  font-family: inherit;
+}
+.filterChip:hover {
+  border-color: var(--ink-4);
+  color: var(--ink);
+}
+.chipCaret {
+  color: var(--ink-4);
+}
+
+/* ---- Panel + table ----------------------------------------------- */
+.panel {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+}
+.list {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 13.5px;
+}
+.list thead th {
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  background: var(--glacier-2);
+  border-bottom: 1px solid var(--line);
+  font-family: var(--font-mplus-rounded), monospace;
+}
+.list thead th:first-child {
+  border-top-left-radius: var(--r-lg);
+  padding-left: 24px;
+}
+.list thead th:last-child {
+  border-top-right-radius: var(--r-lg);
+  padding-right: 24px;
+}
+.list tbody td {
+  padding: 16px;
+  border-bottom: 1px solid var(--line-soft);
+  color: var(--ink);
+  vertical-align: middle;
+}
+.list tbody td:first-child {
+  padding-left: 24px;
+}
+.list tbody td:last-child {
+  padding-right: 24px;
+}
+.list tbody tr:hover td {
+  background: var(--glacier);
+}
+.list tbody tr:last-child td {
+  border-bottom: 0;
+}
+.muted {
+  color: var(--ink-3);
+  font-size: 12.5px;
+}
+.right {
+  text-align: right;
+}
+.num {
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mplus-rounded), monospace;
+  font-weight: 700;
+}
+
+/* ---- Company cell ------------------------------------------------ */
+.coCell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.coCell .logo {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--r);
+  background: linear-gradient(135deg, var(--fjord), var(--mist));
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-family: var(--font-zen-maru), sans-serif;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.coName {
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+.coSub {
+  font-size: 12px;
+  color: var(--ink-4);
+  margin-top: 1px;
+}
+
+/* ---- Status badge ------------------------------------------------ */
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-family: var(--font-zen-maru), sans-serif;
+}
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+.statusOpen {
+  background: rgba(45, 110, 90, 0.1);
+  color: var(--moss);
+}
+.statusOpen .statusDot {
+  background: var(--moss);
+}
+.statusPaused {
+  background: rgba(181, 119, 46, 0.12);
+  color: var(--amber);
+}
+.statusPaused .statusDot {
+  background: var(--amber);
+}
+.statusDraft {
+  background: var(--glacier-2);
+  color: var(--ink-3);
+}
+.statusDraft .statusDot {
+  background: var(--ink-4);
+}
+
+/* ---- Row icon button -------------------------------------------- */
+.rowActions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.iconBtn {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r);
+  cursor: pointer;
+  color: var(--ink-2);
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+.iconBtn:hover {
+  background: var(--paper);
+  border-color: var(--line);
+  color: var(--ink);
+}
+
+/* ---- Focus ring -------------------------------------------------- */
+.wrapper :where(a, button, input):focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}

--- a/src/components/Companies.module.css
+++ b/src/components/Companies.module.css
@@ -119,6 +119,17 @@
   border-color: var(--ink-4);
   color: var(--ink);
 }
+.btn:disabled,
+.iconBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn:disabled:hover,
+.iconBtn:disabled:hover {
+  background: var(--paper);
+  border-color: var(--line);
+  color: var(--ink-2);
+}
 
 /* ---- Toolbar (search + filter chips) ----------------------------- */
 .toolbar {

--- a/src/components/Companies.tsx
+++ b/src/components/Companies.tsx
@@ -18,8 +18,14 @@ export default function Companies() {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const { data } = await supabase.from("companies").select("*");
-      if (!cancelled && data) setCompanies(data);
+      const { data, error } = await supabase.from("companies").select("*");
+      if (cancelled) return;
+      if (error) {
+        console.error("企業一覧の取得に失敗しました", error);
+        setCompanies([]);
+        return;
+      }
+      if (data) setCompanies(data);
     })();
     return () => {
       cancelled = true;
@@ -40,7 +46,13 @@ export default function Companies() {
             </p>
           </div>
           <div className={styles.actions}>
-            <button type="button" className={`${styles.btn} ${styles.btnGhost}`}>
+            <button
+              type="button"
+              className={`${styles.btn} ${styles.btnGhost}`}
+              disabled
+              aria-disabled="true"
+              title="未実装 — 機能は準備中です"
+            >
               CSV出力
             </button>
             <Link href="/companies/new" className={`${styles.btn} ${styles.btnPrimary}`}>
@@ -68,7 +80,10 @@ export default function Companies() {
                 <path d="m20 20-3-3" strokeLinecap="round" />
               </svg>
             </span>
-            <input placeholder="企業名・業種・担当者" />
+            <input
+              aria-label="企業名・業種・担当者で検索"
+              placeholder="企業名・業種・担当者"
+            />
           </div>
           <button type="button" className={styles.filterChip}>
             業種 <span className={styles.chipCaret}>▾</span>
@@ -133,7 +148,14 @@ function CompanyRow({ company }: { company: ICompany }) {
       <td className={styles.muted}>—</td>
       <td className={styles.right}>
         <div className={styles.rowActions}>
-          <button type="button" className={styles.iconBtn} aria-label="編集">
+          <button
+            type="button"
+            className={styles.iconBtn}
+            aria-label="編集"
+            disabled
+            aria-disabled="true"
+            title="未実装 — 機能は準備中です"
+          >
             <svg
               width="14"
               height="14"

--- a/src/components/Companies.tsx
+++ b/src/components/Companies.tsx
@@ -1,125 +1,155 @@
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import supabase from "../lib/supabase";
 import { Database } from "../lib/database.types";
-import Link from "next/link";
+import styles from "./Companies.module.css";
 
 type ICompany = Database["public"]["Tables"]["companies"]["Row"];
+
+function initial(name: string | null): string {
+  if (!name) return "—";
+  const ch = name.replace(/^[(（]?(株|有|合同会社|有限会社|株式会社)[)）]?/u, "").trim()[0];
+  return ch ?? "—";
+}
 
 export default function Companies() {
   const [companies, setCompanies] = useState<ICompany[]>();
 
   useEffect(() => {
     let cancelled = false;
-
     (async () => {
       const { data } = await supabase.from("companies").select("*");
       if (!cancelled && data) setCompanies(data);
     })();
-
     return () => {
       cancelled = true;
     };
   }, []);
 
-  return (
-    <>
-      <div className="py-6 px-4 bg-white">
-        <h1 className="text-xl sm:text-2xl font-semibold text-gray-900">
-          企業
-        </h1>
+  const count = companies?.length ?? 0;
 
-        <div className="sm:flex">
-          <div className="flex items-center space-x-2 sm:space-x-3 ml-auto">
-            <Link
-              href="/companies/new"
-              className="w-1/2 text-white bg-cyan-600 hover:bg-cyan-700 focus:ring-4 focus:ring-cyan-200 font-medium inline-flex items-center justify-center rounded-lg text-sm px-3 py-2 text-center sm:w-auto"
-            >
-              追加
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.inner}>
+        <div className={styles.pageHead}>
+          <div>
+            <div className={styles.tag}>COMPANIES</div>
+            <h1>企業</h1>
+            <p className={styles.sub}>
+              紹介先としてご縁のある {count} 社。最近のやりとりと、現在お預かりしている求人の数をひと目で。
+            </p>
+          </div>
+          <div className={styles.actions}>
+            <button type="button" className={`${styles.btn} ${styles.btnGhost}`}>
+              CSV出力
+            </button>
+            <Link href="/companies/new" className={`${styles.btn} ${styles.btnPrimary}`}>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+              >
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+              企業を追加
             </Link>
           </div>
         </div>
-      </div>
 
-      <div className="overflow-x-auto">
-        <div className="align-middle inline-block min-w-full">
-          <div className="shadow overflow-hidden">
-            <table className="table-fixed min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-100">
-                <tr>
-                  <th
-                    scope="col"
-                    className="p-4 text-left text-xs font-medium text-gray-500 uppercase"
-                  >
-                    Id
-                  </th>
-                  <th
-                    scope="col"
-                    className="p-4 text-left text-xs font-medium text-gray-500 uppercase"
-                  >
-                    Name
-                  </th>
-                  <th
-                    scope="col"
-                    className="p-4 text-left text-xs font-medium text-gray-500 uppercase"
-                  >
-                    Website
-                  </th>
-                  <th
-                    scope="col"
-                    className="p-4 text-left text-xs font-medium text-gray-500 uppercase"
-                  >
-                    Memo
-                  </th>
-                  <th scope="col" className="p-4"></th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {companies?.map((company) => {
-                  return <Company key={company.id} company={company} />;
-                })}
-              </tbody>
-            </table>
+        <div className={styles.toolbar}>
+          <div className={styles.search}>
+            <span className={styles.searchIcon} aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <circle cx="11" cy="11" r="7" />
+                <path d="m20 20-3-3" strokeLinecap="round" />
+              </svg>
+            </span>
+            <input placeholder="企業名・業種・担当者" />
           </div>
+          <button type="button" className={styles.filterChip}>
+            業種 <span className={styles.chipCaret}>▾</span>
+          </button>
+          <button type="button" className={styles.filterChip}>
+            関係性 <span className={styles.chipCaret}>▾</span>
+          </button>
+          <button type="button" className={styles.filterChip}>
+            担当 <span className={styles.chipCaret}>▾</span>
+          </button>
+        </div>
+
+        <div className={styles.panel}>
+          <table className={styles.list}>
+            <thead>
+              <tr>
+                <th>企業</th>
+                <th>業種・所在</th>
+                <th>状況</th>
+                <th style={{ textAlign: "right" }}>公開求人</th>
+                <th style={{ textAlign: "right" }}>進行中候補</th>
+                <th>最終接触</th>
+                <th style={{ width: 80 }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {companies?.map((c) => (
+                <CompanyRow key={c.id} company={c} />
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
-    </>
+    </div>
   );
 }
 
-type CompanyProps = {
-  company: ICompany;
-};
-
-function Company({ company }: CompanyProps) {
+function CompanyRow({ company }: { company: ICompany }) {
   return (
-    <tr className="hover:bg-gray-100">
-      <td className="p-4 whitespace-nowrap text-base font-medium text-gray-900">
-        {company.id}
+    <tr>
+      <td>
+        <div className={styles.coCell}>
+          <div className={styles.logo}>{initial(company.name)}</div>
+          <div>
+            <div className={styles.coName}>{company.name ?? "—"}</div>
+            {company.memo && <div className={styles.coSub}>{company.memo}</div>}
+          </div>
+        </div>
       </td>
-      <td className="p-4 whitespace-nowrap text-base font-medium text-gray-900">
-        {company.name}
+      <td className={styles.muted}>{company.website ?? "—"}</td>
+      <td>
+        <span className={`${styles.status} ${styles.statusOpen}`}>
+          <span className={styles.statusDot}></span>取引中
+        </span>
       </td>
-      <td className="p-4 whitespace-nowrap text-base font-medium text-gray-900">
-        {company.website}
+      <td className={styles.right}>
+        <span className={styles.num}>—</span>
       </td>
-      <td className="p-4 whitespace-nowrap text-base font-medium text-gray-900">
-        {company.memo}
+      <td className={styles.right}>
+        <span className={styles.num}>—</span>
       </td>
-      <td className="p-4 whitespace-nowrap space-x-2">
-        <button
-          type="button"
-          data-modal-toggle="user-modal"
-          className="text-white bg-cyan-600 hover:bg-cyan-700 focus:ring-4 focus:ring-cyan-200 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center"
-        >
-          編集
-        </button>
-        <button
-          type="button"
-          data-modal-toggle="delete-user-modal"
-          className="text-white bg-red-600 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center"
-        >
-          削除
-        </button>
+      <td className={styles.muted}>—</td>
+      <td className={styles.right}>
+        <div className={styles.rowActions}>
+          <button type="button" className={styles.iconBtn} aria-label="編集">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+            >
+              <path
+                d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
       </td>
     </tr>
   );


### PR DESCRIPTION
## Summary
Claude Design からの handoff (`Companies - Fjord direction.html`) を Companies ページに適用しました。

設計は新しい視覚方向 (深いティール `#0E4A50` + Zen Maru Gothic / M PLUS Rounded 1c の和文丸ゴシック基調) で、現状の shadcn/ui ベースの他画面とは大きく異なります。そのため**当該ページ内にスタイルを閉じ込めて**実装しています。

## 変更内容
| File | 変更 |
|---|---|
| `src/components/Companies.module.css` | 新規。設計の `fjord-admin.css` から Companies 画面で使う部分のみ抽出した CSS Modules |
| `src/components/Companies.tsx` | 設計の HTML 構造を React で再実装 |
| `src/app/companies/layout.tsx` | `next/font/google` で Zen Maru Gothic と M PLUS Rounded 1c を CSS 変数化し、Companies ツリー配下にだけ供給 |

## "壊さない" ための工夫
- **スタイルのスコープ**: 全クラスは CSS Modules によりハッシュ化されるため、他ページに影響なし
- **フォント供給範囲**: `companies/layout.tsx` の wrapper にのみ `--font-zen-maru` / `--font-mplus-rounded` を注入。他ページのフォントは従来通り Geist
- **グローバル変更なし**: `globals.css` / `tailwind.config.js` / 他コンポーネントは未変更
- **DB スキーマ未変更**: 既存 `companies` テーブル (`id`, `name`, `website`, `memo`) のみ参照

## 設計と実 DB のギャップ
設計には実 DB に存在しない項目があるため、暫定処理:
- 業種・所在: `website` を流用
- 状況 (取引中 / 休止中 / 初期接触): 全件 "取引中" 表示
- 公開求人数 / 進行中候補数 / 最終接触日: "—" プレースホルダー
- 検索ボックス / フィルタチップ: UI のみ、未配線

これらは将来 DB 拡張時に配線する余地として残しています。

## Test plan
- [ ] `/companies` を開き、新デザインが表示される
- [ ] フォントが Zen Maru Gothic / M PLUS Rounded 1c で表示される
- [ ] **他ページ (`/`, `/dashboard`, `/docs`, `/login`, `/signup` 等) の見た目が従来通り**
- [ ] `npm run build` pass
- [ ] Vercel preview deploy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 企業一覧ページに検索機能と絞り込みフィルター（業界・関係・担当者）を追加しました。

* **スタイル**
  * 企業一覧ページの視覚的なデザインを改善し、企業情報の表示をより見やすく整理しました。企業ロゴ、ステータス、アクションボタンが新しいレイアウトで表示されます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/agent/pull/192)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->